### PR TITLE
fix(app): parse moshaf from multipart form

### DIFF
--- a/src/quran_muaalem/app/serve.py
+++ b/src/quran_muaalem/app/serve.py
@@ -3,8 +3,9 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import Optional
 
 import httpx
-from fastapi import FastAPI, UploadFile, File, Query, Body, Form
+from fastapi import FastAPI, UploadFile, File, Query, Form, Depends
 from fastapi.exceptions import HTTPException
+from pydantic import ValidationError
 
 from quran_transcript import quran_phonetizer, explain_error
 from quran_transcript.phonetics.moshaf_attributes import MoshafAttributes
@@ -18,7 +19,6 @@ from .types import (
     SearchResponse,
     SearchResultResponse,
     CorrectRecitationResponse,
-    CorrectRecitationRequest,
     ReciterErrorResponse,
     PhonemesSearchSpanApp,
     TajweedRuleApp,
@@ -174,6 +174,13 @@ def run_phonetization_and_error(
     return ref_phonetization.phonemes, error_responses
 
 
+def parse_moshaf_from_form(moshaf: str = Form(...)) -> MoshafAttributes:
+    try:
+        return MoshafAttributes.model_validate_json(moshaf, strict=True)
+    except ValidationError as e:
+        raise HTTPException(status_code=422, detail=e.errors())
+
+
 @app.post("/search", response_model=SearchResponse)
 async def search(
     file: UploadFile = File(default=None),
@@ -206,12 +213,10 @@ async def search(
 @app.post("/correct-recitation", response_model=CorrectRecitationResponse)
 async def correct_recitation(
     file: UploadFile = File(...),
-    request: CorrectRecitationRequest = Query(...),
+    moshaf: MoshafAttributes = Depends(parse_moshaf_from_form),
+    error_ratio: float = Form(default=app_settings.error_ratio),
 ):
-    print(request.moshaf.madd_aared_len)
-    moshaf = request.moshaf
-    error_ratio = request.error_ratio
-
+    print(moshaf.madd_aared_len)
     predicted_phonemes = await call_engine_predict(file)
 
     loop = asyncio.get_event_loop()

--- a/tests/test_app_load.py
+++ b/tests/test_app_load.py
@@ -1,6 +1,7 @@
 import asyncio
 import time
 import argparse
+import json
 
 import httpx
 
@@ -70,11 +71,11 @@ async def send_correct_recitation_request(
 ):
     """Send a single /correct-recitation request and return its latency in seconds."""
     files = {"file": ("test.wav", file_bytes, "audio/wav")}
-    json_data = {"moshaf": moshaf, "error_ratio": error_ratio}
+    data = {"moshaf": json.dumps(moshaf), "error_ratio": str(error_ratio)}
     start = time.perf_counter()
     try:
         resp = await client.post(
-            f"{url}/correct-recitation", files=files, json=json_data
+            f"{url}/correct-recitation", files=files, data=data
         )
         resp.raise_for_status()
         if idx == 0:


### PR DESCRIPTION
## Summary
- fix `/correct-recitation` to accept multipart file upload with strict moshaf config parsing
- parse `moshaf` from a form field as JSON string using `MoshafAttributes.model_validate_json(..., strict=True)`
- keep `error_ratio` in multipart form data
- update load test client to send matching multipart payload

## Root Cause
The endpoint expected `CorrectRecitationRequest` from query while also requiring file upload. With `multipart/form-data`, nested config payloads were not parsed as intended.

## What Changed
- `src/quran_muaalem/app/serve.py`
  - replaced query-bound request model with form/dependency parsing:
    - `moshaf: MoshafAttributes = Depends(parse_moshaf_from_form)`
    - `error_ratio: float = Form(default=app_settings.error_ratio)`
  - added `parse_moshaf_from_form` helper with strict validation
- `tests/test_app_load.py`
  - send `moshaf` as `json.dumps(moshaf)` in multipart `data`
  - send `error_ratio` in multipart `data`

## Client Testing Steps
1. Start engine:
   - `uv run quran-muaalem-engine`
2. Start app:
   - `uv run quran-muaalem-app`
3. Call endpoint with multipart:

```bash
curl -X POST 'http://localhost:8001/correct-recitation' \
  -F 'file=@assets/002282_15.wav;type=audio/wav' \
  -F 'error_ratio=0.1' \
  -F 'moshaf={"rewaya":"hafs","madd_monfasel_len":4,"madd_mottasel_len":4,"madd_mottasel_waqf":4,"madd_aared_len":4}'
```

Expected: `200` response with `predicted_phonemes`, `reference_phonemes`, and `errors`.

4. Strict validation check (invalid type):

```bash
curl -X POST 'http://localhost:8001/correct-recitation' \
  -F 'file=@assets/002282_15.wav;type=audio/wav' \
  -F 'moshaf={"rewaya":"hafs","madd_monfasel_len":"4","madd_mottasel_len":4,"madd_mottasel_waqf":4,"madd_aared_len":4}'
```

Expected: `422` validation error.
