### PR TITLE
Fix search error when no results are found (#20)

### DIFF
--- a/src/quran_muaalem/app/serve.py
+++ b/src/quran_muaalem/app/serve.py
@@ -6,7 +6,8 @@ from typing import (
 )
 
 import httpx
-from fastapi import FastAPI, UploadFile, File, Query, Body, Form, Depends
+from fastapi import FastAPI, UploadFile, File, Query, Body, Form, Depends, status
+from fastapi.responses import JSONResponse
 from fastapi.exceptions import HTTPException
 from pydantic import Json
 
@@ -471,7 +472,14 @@ async def correct_recitation(
     )
 
     if not search_results:
-        raise ValueError(message or "No results found. Try increasing error_ratio.")
+        return HTTPException(
+            status_code= status.HTTP_404_NOT_FOUND,
+            headers= {"Content-Type": "application/json"},
+
+            detail= message or "No results found. Try increasing error_ratio."
+        )
+
+        # raise ValueError(message or "No results found. Try increasing error_ratio.")
 
     best_result = search_results[0]
 


### PR DESCRIPTION
This PR fixes the search endpoint when no results are found.

It now returns a 400 status code with a clear error message
instead of a 500 internal server error.

Fixes #20.