### PR TITLE
app: return predicted_phonemes on no-match

### DIFF
--- a/src/quran_muaalem/app/serve.py
+++ b/src/quran_muaalem/app/serve.py
@@ -8,6 +8,7 @@ from typing import (
 import httpx
 from fastapi import FastAPI, UploadFile, File, Query, Body, Form, Depends
 from fastapi.exceptions import HTTPException
+from fastapi.responses import JSONResponse
 from pydantic import Json
 
 
@@ -23,6 +24,7 @@ from .types import (
     SearchResponse,
     SearchResultResponse,
     CorrectRecitationResponse,
+    CorrectRecitationNoMatchResponse,
     ReciterErrorResponse,
     PhonemesSearchSpanApp,
     TajweedRuleApp,
@@ -355,6 +357,12 @@ async def search(
 @app.post(
     "/correct-recitation",
     response_model=CorrectRecitationResponse,
+    responses={
+        404: {
+            "model": CorrectRecitationNoMatchResponse,
+            "description": "Predicted phonemes generated, but no Quran match found",
+        }
+    },
     tags=["Recitation"],
     summary="Analyze and Correct Recitation",
     description="""Analyze audio recording and detect recitation errors with Tajweed rule violations.
@@ -471,7 +479,13 @@ async def correct_recitation(
     )
 
     if not search_results:
-        raise ValueError(message or "No results found. Try increasing error_ratio.")
+        return JSONResponse(
+            status_code=404,
+            content=CorrectRecitationNoMatchResponse(
+                predicted_phonemes=predicted_phonemes,
+                message=message or "No results found. Try increasing error_ratio.",
+            ).model_dump(),
+        )
 
     best_result = search_results[0]
 

--- a/src/quran_muaalem/app/types.py
+++ b/src/quran_muaalem/app/types.py
@@ -135,6 +135,17 @@ class CorrectRecitationResponse(BaseModel):
     )
 
 
+class CorrectRecitationNoMatchResponse(BaseModel):
+    """Response returned when no matching Quran span is found."""
+
+    predicted_phonemes: str = Field(
+        description="Phonetic text from audio prediction"
+    )
+    message: str = Field(
+        description="Reason why matching failed"
+    )
+
+
 def convert_form_value(value: str, field_type):
     """
     Convert a raw form string to the type expected by the model.


### PR DESCRIPTION
## Summary
- return a structured 404 payload from `/correct-recitation` when no Quran match is found
- include `predicted_phonemes` and `message` in that no-match response
- document the 404 schema in OpenAPI via `responses`

## Why
When matching fails, clients still need the transcription output for fallback UX and downstream normalization.

## Notes
- no behavior change for successful matches
- this is an API contract improvement for no-match cases only
