### PR TITLE
Fix ctc_decode emitting the blank id as a final token (#34)

### DIFF
--- a/src/quran_muaalem/decode.py
+++ b/src/quran_muaalem/decode.py
@@ -357,8 +357,10 @@ def ctc_decode(
                         probs.append(
                             batch_probs[seq_idx][start:end].sum() / (end - start)
                         )
-                        tokens.append(next)
-                        probs.append(batch_probs[seq_idx][idx + 1])
+                        # the last item is only a token if it is not a blank
+                        if next != blank_id:
+                            tokens.append(next)
+                            probs.append(batch_probs[seq_idx][idx + 1])
                 # Normal Case
                 elif curr != next and curr != blank_id:
                     end = idx + 1

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -184,6 +184,36 @@ def test_align_predicted_sequence(ref, pred, exp_out, exp_mask):
                 [0.4, 0.8, 0.9, 0.6, 0.8],
             ],
         ),
+        # ends with a single blank: the blank is not a token
+        (
+            [
+                [0, 0, 0, 1, 2, 3, 4, 5, 0],
+            ],
+            [
+                [0.9, 0.9, 0.8, 0.3, 0.2, 0.9, 0.6, 0.8, 0.9],
+            ],
+            [
+                [1, 2, 3, 4, 5],
+            ],
+            [
+                [0.3, 0.2, 0.9, 0.6, 0.8],
+            ],
+        ),
+        # ends with a repeated token then a single blank
+        (
+            [
+                [0, 0, 1, 2, 2, 0],
+            ],
+            [
+                [0.9, 0.9, 0.3, 0.2, 0.4, 0.9],
+            ],
+            [
+                [1, 2],
+            ],
+            [
+                [0.3, 0.3],
+            ],
+        ),
     ],
 )
 def test_ctc_decode(batch_ids, batch_probs, ex_batch_ids, ex_batch_probs):


### PR DESCRIPTION
Fixes #34.

### The bug

In `ctc_decode`, the `collapse_consecutive` branch handles the final pair
separately. When the last two ids differ, it appends `next` without checking it
against `blank_id`:

```python
elif curr != next:
    end = idx + 1
    tokens.append(curr)
    probs.append(batch_probs[seq_idx][start:end].sum() / (end - start))
    tokens.append(next)          # <- appended even when next == blank_id
    probs.append(batch_probs[seq_idx][idx + 1])
```

So a sequence ending in exactly one blank keeps that blank as a decoded token,
and downstream it becomes the literal `[PAD]` in `phonemes.text`.

```
[0, 0, 1, 2, 0]  ->  ids [1, 2, 0]   # expected [1, 2]
```

Only the final position can leak: every other blank is consumed by the
`curr == blank_id` branch, which is also why two or more trailing blanks decode
correctly. That narrowness is why it survives the current tests — every existing
case either ends on a real token or on two blanks.

We hit this on a batch transcription run: 53 clips came back with `[PAD]` inside
`phonemes.text`.

### The fix

Guard the append. One condition, no other path touched.

### Tests

Two cases added to the existing `test_ctc_decode` parametrization:

- `[0, 0, 0, 1, 2, 3, 4, 5, 0]` — single trailing blank
- `[0, 0, 1, 2, 2, 0]` — repeated token then a trailing blank, which also checks
  the averaged probability of the repeat is unaffected

Both fail on `main` and pass with the fix. The 7 existing `test_ctc_decode`
cases, `test_align_predicted_sequence`, `test_sliding_window`,
`test_best_match`, `test_align_phonemes` and `test_merge_lists_with_overlap` all
still pass.

`#33` is already fixed by #36, so this PR does not touch it. `#35` is a
behaviour change rather than a plain bug fix, so it is sent separately.
